### PR TITLE
Add info modal for logging into JL

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
                                                            aria-haspopup="true" aria-expanded="false" title="Online Use Cases" alt="Online Use Cases">
                             WORKFLOWS / USE CASES</a>
                         <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                            <a class="dropdown-item" href="./online-use-cases.html"><span class="item-text">EXPLORE ALL</span></a>
+                            <a class="dropdown-item" href="./online-use-cases-dev.html"><span class="item-text">EXPLORE ALL</span></a>
                             <br>
                             <a class="dropdown-item" target="_blank" href="./docs/"><span class="item-text">GUIDEBOOK</span></a>
                         </div>

--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
                                                            aria-haspopup="true" aria-expanded="false" title="Online Use Cases" alt="Online Use Cases">
                             WORKFLOWS / USE CASES</a>
                         <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                            <a class="dropdown-item" href="./online-use-cases-dev.html"><span class="item-text">EXPLORE ALL</span></a>
+                            <a class="dropdown-item" href="./online-use-cases.html"><span class="item-text">EXPLORE ALL</span></a>
                             <br>
                             <a class="dropdown-item" target="_blank" href="./docs/"><span class="item-text">GUIDEBOOK</span></a>
                         </div>

--- a/online-use-cases-dev.html
+++ b/online-use-cases-dev.html
@@ -240,6 +240,26 @@
             </div>
         </div>
 
+        <div class="modal fade" id="infoModal" tabindex="-1" role="dialog" aria-labelledby="infoModalLabel" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered" role="document">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h5 class="modal-title" id="infoModalLabel">Important!</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+              </div>
+              <div class="modal-body">
+                <p>Please <strong>log in</strong> first to <a href="https://lab.ebrains.eu/" target="_blank">JupyterLab</a>.</p>
+                <p>Once you are logged in, please return to this page to continue your workflow.</p>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+              </div>
+            </div>
+            </div>
+        </div>
+
         <div class="copyright">
             <div class="container">
                 <div class="row">

--- a/online-use-cases-dev.html
+++ b/online-use-cases-dev.html
@@ -262,8 +262,8 @@
                 </button>
               </div>
               <div class="modal-body">
-                <p>Please <strong>log in</strong> first to <a href="https://lab.ebrains.eu/" target="_blank">JupyterLab</a>.</p>
-                <p>Once you are logged in, please return to this page to continue your workflow.</p>
+                <p>Please <strong>log in</strong> first to <a href="https://lab.ebrains.eu/" target="_blank" class="text-primary">JupyterLab</a>.</p>
+                <p>Once you are logged in, return to this page to continue your workflow.</p>
               </div>
               <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>

--- a/online-use-cases-dev.html
+++ b/online-use-cases-dev.html
@@ -240,6 +240,18 @@
             </div>
         </div>
 
+        <div class="copyright">
+            <div class="container">
+                <div class="row">
+                    <div class="col-lg-12">
+                        <p class="p-small"><a href="https://ebrains.eu"></a></p>
+                    </div> <!-- end of col -->
+                </div> <!-- enf of row -->
+            </div> <!-- end of container -->
+        </div> <!-- end of copyright --> 
+        <!-- end of copyright -->
+
+        <!--info Modal-->
         <div class="modal fade" id="infoModal" tabindex="-1" role="dialog" aria-labelledby="infoModalLabel" aria-hidden="true">
             <div class="modal-dialog modal-dialog-centered" role="document">
             <div class="modal-content">
@@ -260,17 +272,6 @@
             </div>
         </div>
 
-        <div class="copyright">
-            <div class="container">
-                <div class="row">
-                    <div class="col-lg-12">
-                        <p class="p-small"><a href="https://ebrains.eu"></a></p>
-                    </div> <!-- end of col -->
-                </div> <!-- enf of row -->
-            </div> <!-- end of container -->
-        </div> <!-- end of copyright --> 
-        <!-- end of copyright -->
-
         <!-- Scripts -->
         <script src="./static/js/jquery.min.js"></script> <!-- jQuery for Bootstrap's JavaScript plugins -->
         <script src="./static/js/popper.min.js"></script> <!-- Popper tooltip library for Bootstrap -->
@@ -282,5 +283,10 @@
         <script src="./static/js/isotope.pkgd.min.js"></script> <!-- Isotope for filter -->
         <script src="./static/js/validator.min.js"></script> <!-- Validator.js - Bootstrap plugin that validates forms -->
         <script src="./static/js/scripts.js"></script> <!-- Custom scripts -->
+        <script>
+            $(document).ready(function () {
+              $('#infoModal').modal('show');
+            });
+        </script>
     </body>
 </html>

--- a/online-use-cases-dev.html
+++ b/online-use-cases-dev.html
@@ -262,7 +262,7 @@
                 </button>
               </div>
               <div class="modal-body">
-                <p>Please <strong>log in</strong> first to <a href="https://lab.ebrains.eu/" target="_blank" class="text-primary">JupyterLab</a>.</p>
+                <p>Please, first <strong>log in</strong> to <a href="https://lab.ebrains.eu/" target="_blank" class="text-primary">JupyterLab</a>.</p>
                 <p>Once you are logged in, return to this page to continue your workflow.</p>
               </div>
               <div class="modal-footer">


### PR DESCRIPTION
Add info modal for logging into EBrains JL when accessing online-use-cases page.
For now the modal is added to the **dev** page, after reviewing we can add it to the main one.

Page url: https://915-misan-teodora.github.io/ebrains-cls-interactive.github.io/online-use-cases-dev.html